### PR TITLE
Sinchronize rsync execution with stdout and stderr pipes read

### DIFF
--- a/rsync.go
+++ b/rsync.go
@@ -207,19 +207,29 @@ func (r Rsync) StderrPipe() (io.ReadCloser, error) {
 	return r.cmd.StderrPipe()
 }
 
-// Run start rsync task
-func (r Rsync) Run() error {
+// Start starts an rsync command
+func (r Rsync) Start() error {
 	if !isExist(r.Destination) {
 		if err := createDir(r.Destination); err != nil {
 			return err
 		}
 	}
 
-	if err := r.cmd.Start(); err != nil {
+	return r.cmd.Start()
+}
+
+// Wait waits for rsync command to finnish
+func (r Rsync) Wait() error {
+	return r.cmd.Wait()
+}
+
+// Run start rsync task. The method is kept here for backward compatibility
+func (r Rsync) Run() error {
+	if err := r.Start(); err != nil {
 		return err
 	}
 
-	return r.cmd.Wait()
+	return r.Wait()
 }
 
 // NewRsync returns task with described options

--- a/task_test.go
+++ b/task_test.go
@@ -1,6 +1,8 @@
 package grsync
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,4 +40,46 @@ func TestTaskSpeedParse(t *testing.T) {
 	const taskInfoString = `0.00kB/s \n 999,999 99%  999.99kB/s    0:00:59 (xfr#9, ir-chk=999/9999)`
 	speed := getTaskSpeed(speedMatcher.ExtractAllStringSubmatch(taskInfoString, 2))
 	assert.Equal(t, "999.99kB/s", speed)
+}
+
+func TestRunTaskSuccess(t *testing.T) {
+	tmpDir := os.TempDir()
+	if tmpDir == "" {
+		tmpDir = "/tmp"
+	}
+	tmpDir = filepath.Join(tmpDir, "grsynctest")
+	e := os.MkdirAll(tmpDir, os.ModeDir|os.ModePerm)
+	assert.Nil(t, e)
+	defer os.RemoveAll(tmpDir)
+	a := filepath.Join(tmpDir, "a")
+	b := filepath.Join(tmpDir, "destDir")
+	f, e := os.Create(a)
+	assert.Nil(t, e)
+	f.Truncate(16 * 1024 * 1024)
+	createdTask := NewTask(a, b, RsyncOptions{})
+	e = createdTask.Run()
+	assert.Nil(t, e)
+	_, e = os.Stat(b)
+	assert.Nil(t, e)
+}
+
+func TestRunTaskFailure(t *testing.T) {
+	tmpDir := os.TempDir()
+	if tmpDir == "" {
+		tmpDir = "/tmp"
+	}
+	tmpDir = filepath.Join(tmpDir, "grsynctest")
+	e := os.MkdirAll(tmpDir, os.ModeDir|os.ModePerm)
+	assert.Nil(t, e)
+	defer os.RemoveAll(tmpDir)
+	a := filepath.Join(tmpDir, "a")
+	b := "/nonwritabledir"
+	f, e := os.Create(a)
+	assert.Nil(t, e)
+	f.Truncate(16 * 1024 * 1024)
+	createdTask := NewTask(a, b, RsyncOptions{})
+	e = createdTask.Run()
+	assert.NotNil(t, e)
+	_, e = os.Stat(b)
+	assert.NotNil(t, e)
 }


### PR DESCRIPTION
This commit ensures the pipes for stdout and stderr are not being
read at the time they are closed. This could cause pipe leaks
leading to goroutines stuck trying to read a pipe without any writer.

Signed-off-by: David Cassany <dcassany@suse.com>